### PR TITLE
bug fix for unknown protocol error

### DIFF
--- a/lib/spree/core/mail_settings.rb
+++ b/lib/spree/core/mail_settings.rb
@@ -18,13 +18,7 @@ module Spree
                    else
                      basic_settings
                    end
-
-        if secure_connection?
-          settings.merge({
-                          enable_starttls_auto: true,
-                          tls: true
-                          })
-        end
+        settings.merge enable_starttls_auto: secure_connection?
       end
 
       class << self


### PR DESCRIPTION
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=unknown state: unknown protocol
from /home/makeanegg/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/protocol.rb:44:in `connect_nonblock'